### PR TITLE
pull contents and index from the working directory

### DIFF
--- a/Game_Maker.hhp
+++ b/Game_Maker.hhp
@@ -1,6 +1,6 @@
 [OPTIONS]
-Contents file=C:\Stuff\github\gm82help\Game_Maker.hhc
-Index file=C:\Stuff\github\gm82help\Game_Maker.hhk
+Contents file=Game_Maker.hhc
+Index file=Game_Maker.hhk
 
 [FILES]
 files\100_index.html


### PR DESCRIPTION
You can't compile the help file currently because it expects the Index and Contents files in a hard-coded location. This changes the location to be the project root, which for most will be the working directory they'll be compiling in.